### PR TITLE
Encapsulation of Default MarkdownRenderer options.

### DIFF
--- a/Sources/PerfectMarkdown/PerfectMarkdown.swift
+++ b/Sources/PerfectMarkdown/PerfectMarkdown.swift
@@ -28,11 +28,35 @@
 import upskirt
 
 #if swift(>=5.0)
-/// an OptionSet setting the markdown extensions to use when rendering using `.markdownToHTML` or `.markdownToXHTML`
-public var markdownExtensionOptions = MarkdownExtensionOptions.default
+@available(*, deprecated, message: "Use MarkdownRenderer.defaultExtensionOptions")
+public var markdownExtensionOptions: MarkdownExtensionOptions {
+  get {
+    MarkdownRenderer.defaultExtensionOptions
+  }
+  set (options) {
+    MarkdownRenderer.defaultExtensionOptions = options
+  }
+}
 
-/// an OptionSet setting the HTML rendering options to use when rendering using `.markdownToHTML` or `.markdownToXHTML`
-public var markdownHTMLRenderOptions = HTMLRenderOptions.default
+@available(*, deprecated, message: "Use MarkdownRenderer.defaultHTMLRenderOptions")
+public var markdownHTMLRenderOptions: HTMLRenderOptions {
+  get {
+    MarkdownRenderer.defaultHTMLRenderOptions
+  }
+  set (options) {
+    MarkdownRenderer.defaultHTMLRenderOptions = options
+  }
+}
+
+public extension MarkdownRenderer {
+
+  /// an OptionSet setting the markdown extensions to use when rendering using `.markdownToHTML` or `.markdownToXHTML`
+  static var defaultHTMLRenderOptions = HTMLRenderOptions.default
+
+  /// an OptionSet setting the HTML rendering options to use when rendering using `.markdownToHTML` or `.markdownToXHTML`
+  static var defaultExtensionOptions = MarkdownExtensionOptions.default
+
+}
 #endif
 
 public extension String {
@@ -76,15 +100,15 @@ public extension String {
 	#if swift(>=5.0)
   /// parse a Markdown string into an XHTML one, return nil if failed
   var markdownToXHTML: String? {
-    renderMarkdown(renderOptions: [markdownHTMLRenderOptions, .useXHTML])
+    renderMarkdown(renderOptions: [MarkdownRenderer.defaultHTMLRenderOptions, .useXHTML])
   }
 	#endif
 
 	#if swift(>=5.0)
   /// renders a Markdown string using `markdownExtensions` and `renderOptions`
   func renderMarkdown(
-    markdownExtensions: MarkdownExtensionOptions = markdownExtensionOptions,
-    renderOptions: HTMLRenderOptions = markdownHTMLRenderOptions
+    markdownExtensions: MarkdownExtensionOptions = MarkdownRenderer.defaultExtensionOptions,
+    renderOptions: HTMLRenderOptions = MarkdownRenderer.defaultHTMLRenderOptions
   ) -> String? {
     MarkdownRenderer(
       markdownExtensions: markdownExtensions,

--- a/Tests/PerfectMarkdownTests/HTMLRenderOptionsTests.swift
+++ b/Tests/PerfectMarkdownTests/HTMLRenderOptionsTests.swift
@@ -12,14 +12,14 @@ class HTMLRenderOptionsTests: XCTestCase {
     withoutOptionString: String
   ) {
 
-    markdownHTMLRenderOptions = option
+    MarkdownRenderer.defaultHTMLRenderOptions = option
 
     XCTAssertEqual(
       markdownString.renderMarkdown(renderOptions: option) ?? "",
       withOptionString + "\n"
     )
 
-    markdownHTMLRenderOptions = withoutOptions
+    MarkdownRenderer.defaultHTMLRenderOptions = withoutOptions
 
     XCTAssertEqual(
       markdownString.renderMarkdown(renderOptions: withoutOptions) ?? "",

--- a/Tests/PerfectMarkdownTests/PerfectMarkdownTests.swift
+++ b/Tests/PerfectMarkdownTests/PerfectMarkdownTests.swift
@@ -5,7 +5,7 @@ class PerfectMarkdownTests: XCTestCase {
 
   override static func setUp() {
 		#if swift(>=5.0)
-    markdownExtensionOptions = MarkdownExtensionOptions.default
+    MarkdownRenderer.defaultExtensionOptions = MarkdownExtensionOptions.default
 		#endif
   }
 


### PR DESCRIPTION
This feature removes (deprecates) `markdownExtensionOptions` and `markdownHTMLRendererOptions` from the global namespace, and replaces them with `static var`s on MarkdownRenderer.

It also renames them to more clearly signal their purpose.